### PR TITLE
feat: add candidate assessment in progress endpoint + ci

### DIFF
--- a/backend/app/api/routes/assessment.py
+++ b/backend/app/api/routes/assessment.py
@@ -14,6 +14,7 @@ from app.services.assessment import (
     save_candidate_response,
     submit_candidate_assessment,
     create_candidate_assessment,
+    start_candidate_assessment,
 )
 from app.schema.candidate_response import (
     CandidateResponseResponse,
@@ -166,6 +167,26 @@ async def submit_assessment(
         db,
         candidate_assessment_id,
     )
+
+
+@router.post(
+    "/take/{access_token}/start",
+    status_code=status.HTTP_200_OK,
+)
+async def start_assessment(
+    access_token: str,
+    db: Session = Depends(get_db),
+):
+    session = start_candidate_assessment(db, access_token)
+    return {
+        "candidate_assess_id": session.candidate_assess_id,
+        "status": session.status.value,
+        "assessment_id": session.assessment_id,
+        "candidate_id": session.candidate_id,
+        "start_time": session.start_time,
+        "end_time": session.end_time,
+        "access_token": session.access_token,
+    }
 
 
 @router.post(

--- a/backend/app/services/assessment.py
+++ b/backend/app/services/assessment.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import json
 import uuid
 
@@ -261,6 +261,49 @@ def submit_candidate_assessment(
     session.status = SessionStatus.COMPLETED
     session.end_time = datetime.utcnow()
 
+    db.commit()
+    db.refresh(session)
+    return session
+
+
+def start_candidate_assessment(
+    db: Session,
+    access_token: str,
+) -> CandidateAssessment:
+    session = (
+        db.query(CandidateAssessment)
+        .filter(CandidateAssessment.access_token == access_token)
+        .first()
+    )
+    if session is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Invalid access token",
+        )
+    if session.status == SessionStatus.IN_PROGRESS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Assessment has already been started",
+        )
+    if session.status == SessionStatus.COMPLETED:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Assessment has already been completed",
+        )
+    if session.status == SessionStatus.EXPIRED:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Assessment has expired",
+        )
+    assessment = (
+        db.query(Assessment)
+        .filter(Assessment.assessment_id == session.assessment_id)
+        .first()
+    )
+    start_time = datetime.utcnow()
+    session.start_time = start_time
+    session.end_time = start_time + timedelta(minutes=assessment.duration_mins)
+    session.status = SessionStatus.IN_PROGRESS
     db.commit()
     db.refresh(session)
     return session

--- a/backend/tests/test_assessment_routes.py
+++ b/backend/tests/test_assessment_routes.py
@@ -429,3 +429,72 @@ def test_invite_candidate_returns_400_when_already_invited(client, mock_db):
         )
     assert response.status_code == 400
     assert "already been invited" in response.json()["detail"]
+
+
+START_PATCH = "app.api.routes.assessment.start_candidate_assessment"
+
+
+def _make_started_session(access_token="valid-token"):
+    mock_session = MagicMock()
+    mock_session.candidate_assess_id = 5
+    mock_session.status = SessionStatus.IN_PROGRESS
+    mock_session.assessment_id = 1
+    mock_session.candidate_id = 2
+    mock_session.access_token = access_token
+    mock_session.start_time = datetime(2025, 1, 1, 12, 0, 0)
+    mock_session.end_time = datetime(2025, 1, 1, 13, 0, 0)
+    return mock_session
+
+
+def test_start_assessment_returns_200_on_valid_token(client, mock_db):
+    mock_session = _make_started_session()
+    with patch(START_PATCH, return_value=mock_session):
+        response = client.post("/api/v1/assessments/take/valid-token/start")
+    assert response.status_code == 200
+
+
+def test_start_assessment_response_includes_start_time_and_end_time(client, mock_db):
+    mock_session = _make_started_session()
+    with patch(START_PATCH, return_value=mock_session):
+        response = client.post("/api/v1/assessments/take/valid-token/start")
+    body = response.json()
+    assert "start_time" in body
+    assert "end_time" in body
+    assert body["start_time"] is not None
+    assert body["end_time"] is not None
+
+
+def test_start_assessment_returns_404_on_invalid_token(client, mock_db):
+    exc = HTTPException(status_code=404, detail="Invalid access token")
+    with patch(START_PATCH, side_effect=exc):
+        response = client.post("/api/v1/assessments/take/bad-token/start")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Invalid access token"
+
+
+def test_start_assessment_returns_400_when_already_in_progress(client, mock_db):
+    exc = HTTPException(
+        status_code=400, detail="Assessment has already been started"
+    )
+    with patch(START_PATCH, side_effect=exc):
+        response = client.post("/api/v1/assessments/take/some-token/start")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Assessment has already been started"
+
+
+def test_start_assessment_returns_400_when_already_completed(client, mock_db):
+    exc = HTTPException(
+        status_code=400, detail="Assessment has already been completed"
+    )
+    with patch(START_PATCH, side_effect=exc):
+        response = client.post("/api/v1/assessments/take/some-token/start")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Assessment has already been completed"
+
+
+def test_start_assessment_returns_400_when_expired(client, mock_db):
+    exc = HTTPException(status_code=400, detail="Assessment has expired")
+    with patch(START_PATCH, side_effect=exc):
+        response = client.post("/api/v1/assessments/take/some-token/start")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Assessment has expired"

--- a/backend/tests/test_assessment_service.py
+++ b/backend/tests/test_assessment_service.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
 import pytest
@@ -13,6 +13,7 @@ from app.services.assessment import (
     get_all_assessments,
     get_assessment_by_id,
     save_candidate_response,
+    start_candidate_assessment,
 )
 from app.schema.candidate_response import ResponseCreate
 
@@ -275,3 +276,112 @@ def test_create_candidate_assessment_access_token_is_valid_uuid():
 
     parsed = uuid.UUID(result.access_token)
     assert str(parsed) == result.access_token
+
+
+def _make_mock_db_for_start(session_result, assessment_result=None):
+    mock_db = MagicMock()
+
+    def query_side_effect(model):
+        mock_q = MagicMock()
+        if model is CandidateAssessment:
+            mock_q.filter.return_value.first.return_value = session_result
+        elif model is Assessment:
+            mock_q.filter.return_value.first.return_value = assessment_result
+        return mock_q
+
+    mock_db.query.side_effect = query_side_effect
+    return mock_db
+
+
+def test_start_candidate_assessment_raises_404_when_token_not_found():
+    mock_db = _make_mock_db_for_start(None)
+    with pytest.raises(HTTPException) as exc_info:
+        start_candidate_assessment(mock_db, "nonexistent-token")
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "Invalid access token"
+
+
+def test_start_candidate_assessment_raises_400_when_in_progress():
+    mock_session = MagicMock()
+    mock_session.status = SessionStatus.IN_PROGRESS
+    mock_db = _make_mock_db_for_start(mock_session)
+    with pytest.raises(HTTPException) as exc_info:
+        start_candidate_assessment(mock_db, "some-token")
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Assessment has already been started"
+
+
+def test_start_candidate_assessment_raises_400_when_completed():
+    mock_session = MagicMock()
+    mock_session.status = SessionStatus.COMPLETED
+    mock_db = _make_mock_db_for_start(mock_session)
+    with pytest.raises(HTTPException) as exc_info:
+        start_candidate_assessment(mock_db, "some-token")
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Assessment has already been completed"
+
+
+def test_start_candidate_assessment_raises_400_when_expired():
+    mock_session = MagicMock()
+    mock_session.status = SessionStatus.EXPIRED
+    mock_db = _make_mock_db_for_start(mock_session)
+    with pytest.raises(HTTPException) as exc_info:
+        start_candidate_assessment(mock_db, "some-token")
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Assessment has expired"
+
+
+def test_start_candidate_assessment_returns_in_progress_status():
+    mock_session = MagicMock()
+    mock_session.status = SessionStatus.STARTED
+    mock_session.assessment_id = 1
+
+    mock_assessment = MagicMock()
+    mock_assessment.duration_mins = 60
+
+    mock_db = _make_mock_db_for_start(mock_session, mock_assessment)
+
+    result = start_candidate_assessment(mock_db, "valid-token")
+    assert result.status == SessionStatus.IN_PROGRESS
+
+
+def test_start_candidate_assessment_sets_start_time():
+    mock_session = MagicMock()
+    mock_session.status = SessionStatus.STARTED
+    mock_session.assessment_id = 1
+
+    mock_assessment = MagicMock()
+    mock_assessment.duration_mins = 60
+
+    mock_db = _make_mock_db_for_start(mock_session, mock_assessment)
+
+    start_candidate_assessment(mock_db, "valid-token")
+    assert isinstance(mock_session.start_time, datetime)
+
+
+def test_start_candidate_assessment_end_time_is_start_plus_duration():
+    mock_session = MagicMock()
+    mock_session.status = SessionStatus.STARTED
+    mock_session.assessment_id = 1
+
+    mock_assessment = MagicMock()
+    mock_assessment.duration_mins = 45
+
+    mock_db = _make_mock_db_for_start(mock_session, mock_assessment)
+
+    start_candidate_assessment(mock_db, "valid-token")
+    assert mock_session.end_time == mock_session.start_time + timedelta(minutes=45)
+
+
+def test_start_candidate_assessment_end_time_greater_than_start_time():
+    mock_session = MagicMock()
+    mock_session.status = SessionStatus.STARTED
+    mock_session.assessment_id = 1
+
+    mock_assessment = MagicMock()
+    mock_assessment.duration_mins = 30
+
+    mock_db = _make_mock_db_for_start(mock_session, mock_assessment)
+
+    start_candidate_assessment(mock_db, "valid-token")
+    assert mock_session.end_time > mock_session.start_time


### PR DESCRIPTION
This PR was for the endpoint we discovered we had not thought of for the candidate to start the assessment. The candidate will press a button to start the assessment and the endpoint will validate the access token and update the candidate assessment accordingly. This closes ticket #75 